### PR TITLE
Add Team Logo to README and Update Formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
-# Animal-Crate
+<p align="center"> <img alt="Animal Crate" width="900" height="300" src="https://github.com/Animal-Crate/Animal-Crate/blob/master/Team-Logo.png" /></p>
+
 This is a repository for the ECE 490/491 class. The code provided here is specifically open-source when all is said and done.
+
 This is a capstone project that we are working on as a team, the system for all of our code and interactions.
 
-### Our Goal
+---
+
+## Our Goal
 The provided code will be organized, commented, and user-friendly to allow for the ultimate configuration based on needs and systems. This is our goal as the members working on this project, to ensure that it is robust and well-rounded, allowing those without prior coding knowledge to make changes to suit their needs.
 
 ## Acknowledgements
-Please note that the commit [ab4d98c](https://github.com/CerberusWolfie/Animal-Crate/commit/ab4d98cc3e09a14c0073a8962853a0c809742049) has added the library for dependencies for ease of use when taking code from this repository (or cloning/forking it).
-The files shown in https://github.com/CerberusWolfie/Animal-Crate/tree/master/MFRC522 are directly taken from https://github.com/miguelbalboa/rfid and are allowed under the non-licensed content.
+Please note that the files shown in [MFRC522](https://github.com/Animal-Crate/Animal-Crate/tree/master/MFRC522) are taken from another repository. These are not licensed under this repository's license, and you can find more information in the README section in that directory.


### PR DESCRIPTION
Simply adds the logo to the README and reduces the redundancy by formatting it differently.