### PR TITLE
Add Arduino Files to Labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -10,6 +10,7 @@
     - any-glob-to-any-file:
         - "**/*.c"
         - "**/*.cpp"
+        - "**/*.ino"
 
 "Changes: Headers":
   - changed-files:


### PR DESCRIPTION
This adds the .ino extension to the labeler so it doesn't forget to flag Arduino changes.