### PR TITLE
Add CAD to Labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -12,6 +12,15 @@
         - "**/*.cpp"
         - "**/*.ino"
 
+"Changes: CAD Files":
+  - changed-files:
+    - any-glob-to-any-file:
+      - "**/*.3mf"
+      - "**/*.step"
+      - "**/*.STEP"
+      - "**/*.stl"
+      - "**/*.STL"
+
 "Changes: Headers":
   - changed-files:
     -  any-glob-to-any-file: "**/*.h"
@@ -32,6 +41,7 @@
     - any-glob-to-any-file:
       - "**/*.txt"
       - "**/*.md"
+      - "**/*.pdf"
 
 "Changes: Images":
   - changed-files:
@@ -39,6 +49,7 @@
       - "**/*.png"
       - "**/*.jpg"
       - "**/*.jpeg"
+      - "**/*.svg"
       - "**/*.webp"
 
 "Changes: PCB Files":

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -16,6 +16,8 @@
   - changed-files:
     - any-glob-to-any-file:
       - "**/*.3mf"
+      - "**/*.fbx"
+      - "**/*.obj"
       - "**/*.step"
       - "**/*.STEP"
       - "**/*.stl"


### PR DESCRIPTION
# Description
Adds the CAD model file extensions to the labeler so we can keep track of labeling for 3D models. These are the basic ones used for our project, and includes .obj and .fbx, but not others.